### PR TITLE
Created image file format README with official recommendations

### DIFF
--- a/File Formats/Images/README.md
+++ b/File Formats/Images/README.md
@@ -1,0 +1,13 @@
+# Image File Formats
+
+## Official Recommendations
+
+Rather than creating your own format or using a lesser used format, it is recommended to use the following formats based on your needs.
+
+**Images that require both text and colour in each pixel (advanced computers)**: [NitroFingers Text](todo)
+
+**Images that only require 1 colour per pixel**: [Universal Compressed Graphics Format](todo)
+
+## Proposal Requirements
+
+Image file format proposals must follow the [File Format proposal requirements](https://github.com/oeed/CraftOS-Standards/blob/master/File%20Formats/README.md#proposal-requirements).

--- a/File Formats/Images/README.md
+++ b/File Formats/Images/README.md
@@ -2,7 +2,7 @@
 
 ## Official Recommendations
 
-Rather than creating your own format or using a lesser used format, it is recommended to use the following formats based on your needs.
+Rather than creating your own format or using a lesser used/inefficient format, it is recommended to use the following formats based on your needs.
 
 **Images that require both text and colour in each pixel (advanced computers)**: [NitroFingers Text](todo)
 


### PR DESCRIPTION
The main issue involves the official recommendations #6 

I personally do not think the paint image format should be a recommended format. Although it has not yet been publicly been released, UCG (by ardera) is a far more efficient format (honestly, it can shrink file sizes to below 20% of the original size).

The issue is, however, unless Dan implements UCG in the paint program (which he should IMO) people are going to use paint, especially until there's an editor available for UCG images.

As UCG is as efficient in lower sizes, perhaps we only recommend paint for small images?
