### PR TITLE
Improve formatting of Standard Proposal Guidelines

### DIFF
--- a/File-Formats/TEMPLATE.md
+++ b/File-Formats/TEMPLATE.md
@@ -1,18 +1,21 @@
-**This file is a template of how a standard proposal document should look like.**
+**This file is a template of how a file format standard should look.**
 
 ---
 
-# _Standard Name_
-| Information	|																						                                            |
-|-------------|---------------------------------------------------------------------------------------|
-| Version 		| [semver](http://semver.org) version tag												                        |	
-| Type		  	| Category																				                                      |
-| MIME		  	| `mime/type`																			                                      |
-| Extensions	| `.extension1`; `.extension2` (Use `none` if your standard does not use file extensions)	|
-| Deprecates	| (List) Names of standards deprecated by _Standard Name_				                  			|
+# *COS num:* _Standard Name_
+
+## Quick information
+| Information |                                                                                        |
+| ----------- | -------------------------------------------------------------------------------------- |
+| Version     | [semver](http://semver.org) version tag                                                |
+| Type        | Category                                                                               |
+| MIME        | `mime/type`                                                                            |
+| Extensions  | `.extension1`; `.extension2` (Use `none` if your standard does not use file extensions)|
+| Deprecates  | (List) Names of standards deprecated by _Standard Name_                                |
 
 ### Technical Details
 Thorough description of _Standard Name_, including but not limited to notes on [backward](https://en.wikipedia.org/wiki/Backward_compatibility) and [forward](https://en.wikipedia.org/wiki/Forward_compatibility) compatibility (such as upgrading from an old version of the format), safety measures, APIs and libraries and ways to load and initialize them, and an in-depth description of the file structure (if any).
+
 #### Available Utilities
 List of all utilities that come with the standard, with links to their source code.
 > **Note**: A file format proposal should at least include utilities for writing and parsing it!

--- a/File-Formats/image/nft.md
+++ b/File-Formats/image/nft.md
@@ -5,7 +5,7 @@
 | Information |                           |
 | ----------- | ------------------------- |
 | Type        | Image file format         |
-| MIME        | `image/nft`             |
+| MIME        | `image/nft`               |
 | Extensions  | `.nft`                    |
 
 ## Technical details
@@ -16,7 +16,7 @@ Unlike the paintutils format, however, this format allows characters and text co
 
 ### Special characters
 
-The format uses two special characters, a character whose byte is `30` and another whose byte is `31`. 
+The format uses two special characters, a character whose byte is `30` and another whose byte is `31`.
 
 
 | Byte | Represents |

--- a/Miscellaneous-Standards/Temporary Directory.md
+++ b/Miscellaneous-Standards/Temporary Directory.md
@@ -1,19 +1,21 @@
 # *COS 7:* Temporary Directory
-| Information	|																						                                            |
-|-------------|---------------------------------------------------------------------------------------|
-| Type		  	| Path / Directory									
-| Location	| Temporary Directory is located in `/tmp`	|
+
+## Quick information
+| Information |                                                                 |
+| ----------- | --------------------------------------------------------------- |
+| Type        | Path / Directory                                                |
+| Location    | Temporary Directory is located in `/tmp`                        |
 
 ### Technical Details
 A standard temp directory exists at `/tmp`
 
 This directory is used for storing files temporarily. The point of this directory is to be able to have a standard place to store "junk" files, where the program doesn't have to worry about accidentally overriding another file created by the user. It is NOT a place to store any files that need to be accurately recalled later on.
 
-**Proper Usage in Supporting Programs**
+#### Proper Usage in Supporting Programs
 
 To use it properly, a program can (through normal non-interrupted execution) store files in the `/tmp` directory while it is running, and then should promptly delete the file from this directory as soon as possible.
 
-**Proper Support in Supporting OSes (and other systems)**
+#### Proper Support in Supporting OSes (and other systems)
 
 The `/tmp` folder should be deleted then recreated at the startup of the system. Access to this directory should be open and unprotected. It can however be hidden by the operating system, however, this is at the discretion of the OS creator (and hopefully a user-modifiable config setting as well). **Ensure that you are only hiding /tmp and not other folders called tmp**
 

--- a/Tutorial/StandardProposalGuidelines.md
+++ b/Tutorial/StandardProposalGuidelines.md
@@ -2,17 +2,20 @@
 
 ---
 
-# _Standard Name_
-| Information	|																						                                            |
-|-------------|---------------------------------------------------------------------------------------|
-| Version 		| [semver](http://semver.org) version tag												                        |	
-| Type		  	| Category																				                                      |
-| MIME		  	| `mime/type`																			                                      |
-| Extensions	| `.extension1`; `.extension2` (Use `none` if your standard does not use file extensions)	|
-| Deprecates	| (List) Names of standards deprecated by _Standard Name_				                  			|
+# *COS num:* _Standard Name_
+
+## Quick information
+| Information |                                                                                        |
+| ----------- | -------------------------------------------------------------------------------------- |
+| Version     | [semver](http://semver.org) version tag                                                |
+| Type        | Category                                                                               |
+| MIME        | `mime/type`                                                                            |
+| Extensions  | `.extension1`; `.extension2` (Use `none` if your standard does not use file extensions)|
+| Deprecates  | (List) Names of standards deprecated by _Standard Name_                                |
 
 ### Technical Details
 Thorough description of _Standard Name_, including but not limited to notes on [backward](https://en.wikipedia.org/wiki/Backward_compatibility) and [forward](https://en.wikipedia.org/wiki/Forward_compatibility) compatibility (such as upgrading from an old version of the format), safety measures, APIs and libraries and ways to load and initialize them, and an in-depth description of the file structure (if any).
+
 #### Available Utilities
 List of all utilities that come with the standard, with links to their source code.
 > **Note**: A file format proposal should at least include utilities for writing and parsing it!


### PR DESCRIPTION
- Replace tabs with spaces
- Add COS number requirement
- Add "Quick information" header to remain consistent with other standards.
- Reformat several standards to be correctly aligned.

Several inconsistencies I've noticed:

[Universal Compressed Graphics](https://github.com/oeed/CraftOS-Standards/blob/master/File-Formats/image/ucg.md) takes a very different form to any other standard. I'm fine with this: it is very well written, but we may want to adjust the guidelines to account for this.

[TemporaryDirectory](https://github.com/oeed/CraftOS-Standards/blob/master/Miscellaneous-Standards/Temporary%20Directory.md) uses a different set of fields to any other standard: namely it is lacking a version field.

I also don't know if we want to define a specific column width that documents must be limited to.
