### PR TITLE
Terminal Redirection over Rednet

### DIFF
--- a/Protocols/tror.md
+++ b/Protocols/tror.md
@@ -68,7 +68,7 @@ terminal has taken.
 | `TV` | `[<f,b,t>:]`    | Sets the entire terminal's contents. Each line is separated by the `:` character and composed of the foreground, background colors and text. All fields across all lines MUST be the same length. |
 
 \* All colors use the codes defined in [COS 4][cospaint]. The client MAY choose
-to ignore colours if it is incapable of rendering them.
+to ignore colors if it is incapable of rendering them.
 
 † All fields being the same length allows the packet parser to read `n`
 characters once the first `,` has been found. The implementation SHOULD discard
@@ -135,7 +135,7 @@ The table MUST contain the following fields:
 | `backColor`   | A table representing the textual contents of the terminal.\*†|
 
 \* All colors use the codes defined in [COS 4][cospaint]. The client MAY choose
-to ignore colours if it is incapable of rendering them.
+to ignore colors if it is incapable of rendering them.
 
 † Each entry of the table represents a separate line of the terminal. There must
 be `sizeY` table entries, each being `sizeX` characters long.

--- a/Protocols/tror.md
+++ b/Protocols/tror.md
@@ -3,7 +3,7 @@
 ## Quick information
 | Information |                                                                |
 | ----------- | -------------------------------------------------------------- |
-| Version     | 1.0                                                            |
+| Version     | 1.0.0                                                          |
 | Type        | Protcol                                                        |
 
 ## Technical Details
@@ -79,12 +79,14 @@ response packet.
 | Code | Packet contents | Description                                                   |
 | ---- | --------------- | ------------------------------------------------------------- |
 | `TQ` | None            | Queries the client for terminal dimensions and color support. |
+| `TG` | None            | Queries the client for the current cursor position.           |
 
-The client SHOULD send an appropriate response packet to these requests:
+The client should send an appropriate response packet to these requests:
 
 | Code | Packet contents | Description                                         |
 | ---- | --------------- | --------------------------------------------------- |
 | `TI` | `<w>,<h>,<col>` | Send the client terminal's width, height and color support to the server. This packet MAY be sent at any time and SHOULD be sent whenever a `TQ` packet is received. |
+| `TG` | `<x>,<y>`       | Send the client terminal's cursor position. This MUST be sent when receiving a `TG` packet and SHOULD NOT be sent at any other time. |
 
 ### Client events
 The client MAY send events such as key presses to the client. However the client

--- a/Protocols/tror.md
+++ b/Protocols/tror.md
@@ -39,7 +39,7 @@ determining what extensions to the protocol the client supports.
 
 | Code | Payload         | Description                                         |
 | ---- | --------------- | --------------------------------------------------- |
-| `SP` | None            | Requests the supported extensions from the client.  |
+| `SP` | `<extensions>`  | Carries the extensions supported by the server and requests a capability list from the client. Each extension should be surrounded in hyphens. This packet MAY be sent at any time. |
 | `SC` | `<message>`     | Closes this connection. The server SHOULD NOT send any more packets after this one, nor handle any incoming packets. |
 
 Some packets require the client to respond.

--- a/Protocols/tror.md
+++ b/Protocols/tror.md
@@ -92,7 +92,7 @@ The client should send an appropriate response packet to these requests:
 | `TP` | `<x>,<y>`       | Carries the client terminal's cursor position. This MUST be sent when receiving a `TG` packet and SHOULD NOT be sent at any other time. |
 
 ### Client events
-The client MAY send events such as key presses to the client. However the client
+The client MAY send events such as key presses to the client. However the server
 MAY ignore these.
 
 | Code | Payload             | Description                                     |

--- a/Protocols/tror.md
+++ b/Protocols/tror.md
@@ -1,0 +1,88 @@
+# *COS 10:* Terminal Redirection over Rednet
+
+## Quick information
+| Information |                                                                |
+| ----------- | -------------------------------------------------------------- |
+| Version     | 1.0                                                            |
+| Type        | Protcol                                                        |
+
+### Technical Details
+Terminal Redirection over Rednet, or TRoR, defines a method of broadcasting a
+terminal from one computer (the sever) to one client.
+
+The server and client communicate via a series of "packets". Packets are
+generally sent with one packet per rednet message, but multiple packets MAY
+be sent at once with each being deliminated with the line feed (LF) character
+(`\n`, ASCCI code 10). Consequently, the packet contents CANNOT contain the LF
+character.
+
+Packets are composed of 3 components:
+
+ - A two character packet code. This defines the command to execute. An unknown
+   command MUST be discarded.
+ - Optional implementation-specific data about the packet. Arbitary data MAY be
+   placed here but SHALL NOT contain a semicolon (`;`) or LF character. The
+   implementation MUST NOT malfunction if data is found here.
+ - The main packet contents.
+
+These components are combined in the format:
+```
+<Packet code>:<Metadata>;<Packet contents>
+```
+
+#### Terminal broadcasting packets
+The main purpose of TRoR is to broadcast the terminal state over rednet. The
+following packets  are sent from the server to the client to specify actions the
+terminal has taken.
+
+| Code | Packet contents | Description                                                                 |
+| ---- | --------------- | ----------------------------------------------------------------------------|
+| `TW` | `<text>`        | Carries the written text to the client. The LF character should be replaced with a space. |
+| `TC` | `<x>,<y>`       | Sets the cursor position on the client screen                               |
+| `TE` | None            | Clears the client's screen                                                  |
+| `TL` | None            | Clears the current line on the client                                       |
+| `TS` | `<count>`       | Scrolls the client screen by a set number of lines.                         |
+| `TB` | `<blink>`       | Sets the cursor blink where `true` is blinking and `false` is not blinking. |
+| `TF` | `<color>`       | Sets the foreground color. This uses the codes defined in [COS 4][cospaint]. The client MAY choose to ignore colours if it incapible of rendering them. |
+| `TK` | `<color>`       | Sets the background color. This uses the codes defined in [COS 4][cospaint]. The client MAY choose to ignore colours if it incapible of rendering them. |
+| `TR` | `<w>,<h>`       | Sets the size of the client terminal in width and height. The client MAY chose to discard data which does not fit on the screen.                        |
+| `TY` | `<f,b,t>`       | Sets the foreground, background and text of the current line. All three fields MUST be the same length.                                                 |
+| `TT` | `[<f,b,t>:]`    | Sets the entire terminal. Each line is separated by the `:` character and composed of the foreground, background colors and text. All fields across all lines MUST be the same length. |
+
+#### Client querying commands
+The server MAY send packets to the client to determine information about the
+client such as color capabilities. The client SHOULD send an appropriate
+response packet.
+
+| Code | Packet contents | Description                                         |
+| ---- | --------------- | --------------------------------------------------- |
+| `TD` | None            | Queries the client for terminal dimensions          |
+| `TA` | None            | Queries the client for color support.               |
+
+The client SHOULD send an appropriate response packet to these requests:
+
+| Code | Packet contents | Description                                                               |
+| ---- | --------------- | ------------------------------------------------------------------------- |
+| `TI` | `<w>,<h>,<col>` | Send the client terminal's width, height and color support to the server. |
+
+#### Client events
+The client MAY send events such as key presses to the client. However the client
+MAY ignore these.
+
+| Code | Packet contents     | Description                                     |
+| ---- | ------------------- | ----------------------------------------------- |
+| `EV` | `<event,arg1,arg2>` | Queue an event on the server.                   |
+
+The event name and its arguments should be displayed as the appropriate boolean,
+string or number literal. Strings must use double quotes and escape the LF
+character.
+
+Lua tables MAY be included as an argument, though an implementation is allowed to
+discard it. Other Lua expressions such as binary operators or functions MUST NOT
+be transmitted and SHOULD NOT be executed.
+
+#### Available Utilities
+ - [nsh and its related utilities](https://github.com/lyqyd/cc-netshell/) does things
+   differently.
+
+[cospaint]: /File-Formats/image/paint.md "COS 4: Paintutils Image"

--- a/Protocols/tror.md
+++ b/Protocols/tror.md
@@ -43,21 +43,27 @@ terminal has taken.
 | `TL` | None            | Clears the current line on the client                                       |
 | `TS` | `<count>`       | Scrolls the client screen by a set number of lines.                         |
 | `TB` | `<blink>`       | Sets the cursor blink where `true` is blinking and `false` is not blinking. |
-| `TF` | `<color>`       | Sets the foreground color. This uses the codes defined in [COS 4][cospaint]. The client MAY choose to ignore colours if it incapible of rendering them. |
-| `TK` | `<color>`       | Sets the background color. This uses the codes defined in [COS 4][cospaint]. The client MAY choose to ignore colours if it incapible of rendering them. |
-| `TR` | `<w>,<h>`       | Sets the size of the client terminal in width and height. The client MAY chose to discard data which does not fit on the screen.                        |
-| `TY` | `<f,b,t>`       | Sets the foreground, background and text of the current line. All three fields MUST be the same length.                                                 |
-| `TT` | `[<f,b,t>:]`    | Sets the entire terminal. Each line is separated by the `:` character and composed of the foreground, background colors and text. All fields across all lines MUST be the same length. |
+| `TF` | `<color>`       | Sets the foreground color.\*                                                |
+| `TK` | `<color>`       | Sets the background color.\*                                                |
+| `TR` | `<w>,<h>`       | Sets the size of the client terminal in width and height. The client MAY chose to discard data which does not fit on the screen. |
+| `TY` | `<f,b,t>`       | Sets the foreground, background and text of the current line. All three fields MUST be the same length.\*†                       |
+| `TV` | `[<f,b,t>:]`    | Sets the entire terminal. Each line is separated by the `:` character and composed of the foreground, background colors and text. All fields across all lines MUST be the same length. |
+
+\* All colors use the codes defined in [COS 4][cospaint]. The client MAY choose
+to ignore colours if it incapible of rendering them.
+
+† All fields being the same length allows the packet parser to read `n`
+characters once the first `,` has been found. The implementation SHOULD discard
+the packet if each field is not the same length but MAY attempt to recover.
 
 #### Client querying commands
 The server MAY send packets to the client to determine information about the
 client such as color capabilities. The client SHOULD send an appropriate
 response packet.
 
-| Code | Packet contents | Description                                         |
-| ---- | --------------- | --------------------------------------------------- |
-| `TD` | None            | Queries the client for terminal dimensions          |
-| `TA` | None            | Queries the client for color support.               |
+| Code | Packet contents | Description                                                   |
+| ---- | --------------- | ------------------------------------------------------------- |
+| `TQ` | None            | Queries the client for terminal dimensions and color support  |
 
 The client SHOULD send an appropriate response packet to these requests:
 
@@ -73,9 +79,9 @@ MAY ignore these.
 | ---- | ------------------- | ----------------------------------------------- |
 | `EV` | `<event,arg1,arg2>` | Queue an event on the server.                   |
 
-The event name and its arguments should be displayed as the appropriate boolean,
-string or number literal. Strings must use double quotes and escape the LF
-character.
+The event name and its arguments should be displayed as the appropriate nil,
+boolean, string or number literal. Strings must use double quotes and escape the
+LF character.
 
 Lua tables MAY be included as an argument, though an implementation is allowed to
 discard it. Other Lua expressions such as binary operators or functions MUST NOT

--- a/Protocols/tror.md
+++ b/Protocols/tror.md
@@ -30,6 +30,9 @@ These components are combined in the format:
 <Packet code>:<Metadata>;<Packet contents>
 ```
 
+The packet MUST take this exact format even if one component is empty. Both 
+`:` and `;` MUST be present.
+
 ### Connection management
 The server MAY send packets to the client to handle the connection, such as
 determining what extensions to the protocol the client supports.

--- a/Protocols/tror.md
+++ b/Protocols/tror.md
@@ -4,7 +4,7 @@
 | Information |                                                                |
 | ----------- | -------------------------------------------------------------- |
 | Version     | 1.0.0                                                          |
-| Type        | Protcol                                                        |
+| Type        | Protocol                                                       |
 
 ## Technical Details
 Terminal Redirection over Rednet, or TRoR, defines a method of broadcasting a
@@ -12,39 +12,39 @@ terminal from one computer (the sever) to one client.
 
 The server and client communicate via a series of "packets". Packets are
 generally sent with one packet per rednet message, but multiple packets MAY
-be sent at once with each being deliminated with the line feed (LF) character
-(`\n`, ASCCI code 10). Consequently, the packet contents CANNOT contain the LF
+be sent at once with each being delimited with the line feed (LF) character
+(`\n`, ASCII code 10). Consequently, the packet's payload CANNOT contain the LF
 character.
 
 Packets are composed of 3 components:
 
  - A two character packet code. This defines the command to execute. An unknown
    command MUST be discarded.
- - Optional implementation-specific data about the packet. Arbitary data MAY be
-   placed here but SHALL NOT contain a semicolon (`;`) or LF character. The
+ - Optional implementation-specific data about the packet. Arbitrary data MAY be
+   placed here but SHALL NOT contain a semicolon (`;`) or a LF character. The
    implementation MUST NOT malfunction if data is found here.
- - The main packet contents.
+ - The packet's payload.
 
 These components are combined in the format:
 ```
-<Packet code>:<Metadata>;<Packet contents>
+<Code>:<Metadata>;<Payload>
 ```
 
-The packet MUST take this exact format even if one component is empty. Both 
+The packet MUST take this exact format even if one component is empty. Both
 `:` and `;` MUST be present.
 
 ### Connection management
 The server MAY send packets to the client to handle the connection, such as
 determining what extensions to the protocol the client supports.
 
-| Code | Packet contents | Description                                         |
+| Code | Payload         | Description                                         |
 | ---- | --------------- | --------------------------------------------------- |
-| `SP` | None            | Request the supported extensions from the client    |
-| `SC` | `<message>`     | Close this connection. The server SHOULD NOT send any more packets after this one, nor handle any incomming packets. |
+| `SP` | None            | Requests the supported extensions from the client.  |
+| `SC` | `<message>`     | Closes this connection. The server SHOULD NOT send any more packets after this one, nor handle any incoming packets. |
 
 Some packets require the client to respond.
 
-| Code | Packet contents | Description                                         |
+| Code | Payload         | Description                                         |
 | ---- | --------------- | --------------------------------------------------- |
 | `SP` | `<extensions>`  | Carries the extensions supported by the client. Each extension should be surrounded in hyphens. This packet MAY be sent at any time and SHOULD be sent whenever a `SP` packet is received. |
 
@@ -53,22 +53,22 @@ The main purpose of TRoR is to broadcast the terminal state over rednet. The
 following packets  are sent from the server to the client to specify actions the
 terminal has taken.
 
-| Code | Packet contents | Description                                                                 |
+| Code | Payload         | Description                                                                 |
 | ---- | --------------- | ----------------------------------------------------------------------------|
 | `TW` | `<text>`        | Carries the written text to the client. The LF character should be replaced with a space. |
-| `TC` | `<x>,<y>`       | Sets the cursor position on the client screen                               |
-| `TE` | None            | Clears the client's screen                                                  |
-| `TL` | None            | Clears the current line on the client                                       |
+| `TC` | `<x>,<y>`       | Sets the cursor position on the client screen.                              |
+| `TE` | None            | Clears the client's screen.                                                 |
+| `TL` | None            | Clears the current line on the client.                                      |
 | `TS` | `<count>`       | Scrolls the client screen by a set number of lines.                         |
 | `TB` | `<blink>`       | Sets the cursor blink where `true` is blinking and `false` is not blinking. |
 | `TF` | `<color>`       | Sets the foreground color.\*                                                |
 | `TK` | `<color>`       | Sets the background color.\*                                                |
 | `TR` | `<w>,<h>`       | Sets the size of the client terminal in width and height. The client MAY chose to discard data which does not fit on the screen. |
 | `TY` | `<f,b,t>`       | Sets the foreground, background and text of the current line. All three fields MUST be the same length.\*†                       |
-| `TV` | `[<f,b,t>:]`    | Sets the entire terminal. Each line is separated by the `:` character and composed of the foreground, background colors and text. All fields across all lines MUST be the same length. |
+| `TV` | `[<f,b,t>:]`    | Sets the entire terminal's contents. Each line is separated by the `:` character and composed of the foreground, background colors and text. All fields across all lines MUST be the same length. |
 
 \* All colors use the codes defined in [COS 4][cospaint]. The client MAY choose
-to ignore colours if it incapible of rendering them.
+to ignore colours if it is incapable of rendering them.
 
 † All fields being the same length allows the packet parser to read `n`
 characters once the first `,` has been found. The implementation SHOULD discard
@@ -79,25 +79,25 @@ The server MAY send packets to the client to determine information about the
 client such as color capabilities. The client SHOULD send an appropriate
 response packet.
 
-| Code | Packet contents | Description                                                   |
+| Code | Payload         | Description                                                   |
 | ---- | --------------- | ------------------------------------------------------------- |
 | `TQ` | None            | Queries the client for terminal dimensions and color support. |
 | `TG` | None            | Queries the client for the current cursor position.           |
 
 The client should send an appropriate response packet to these requests:
 
-| Code | Packet contents | Description                                         |
+| Code | Payload         | Description                                         |
 | ---- | --------------- | --------------------------------------------------- |
-| `TI` | `<w>,<h>,<col>` | Send the client terminal's width, height and color support to the server. This packet MAY be sent at any time and SHOULD be sent whenever a `TQ` packet is received. |
-| `TP` | `<x>,<y>`       | Send the client terminal's cursor position. This MUST be sent when receiving a `TG` packet and SHOULD NOT be sent at any other time. |
+| `TI` | `<w>,<h>,<col>` | Carries the client terminal's width, height and color support to the server. This packet MAY be sent at any time and SHOULD be sent whenever a `TQ` packet is received. |
+| `TP` | `<x>,<y>`       | Carries the client terminal's cursor position. This MUST be sent when receiving a `TG` packet and SHOULD NOT be sent at any other time. |
 
 ### Client events
 The client MAY send events such as key presses to the client. However the client
 MAY ignore these.
 
-| Code | Packet contents     | Description                                     |
+| Code | Payload             | Description                                     |
 | ---- | ------------------- | ----------------------------------------------- |
-| `EV` | `<event,arg1,arg2>` | Queue an event on the server.                   |
+| `EV` | `<event,arg1,arg2>` | Queues an event on the server.                  |
 
 The event name and its arguments should be displayed as the appropriate nil,
 boolean, string or number literal. Strings must use double quotes and escape the
@@ -116,12 +116,12 @@ Support of this extension SHOULD be shown by including the `textTable` in the
 `SP` packet. This extension MUST NOT be used if the client does not indicate its
 support and `TV` should be used instead.
 
-| Code | Packet contents     | Description                                     |
-| ---- | ------------------- | ----------------------------------------------- |
-| `TT` | `<payload>`         | Sets the entire terminal.                       |
+| Code | Payload         | Description                                         |
+| ---- | --------------- | --------------------------------------------------- |
+| `TT` | `<payload>`     | Sets the entire terminal's state.                   |
 
-The packet payload should be a serialized table and MUST NOT contain the LF
-character. The table MUST contain the following fields:
+The payload should be a serialized table and MUST NOT contain the LF character.
+The table MUST contain the following fields:
 
 | Field         | Description                                                  |
 | ------------- | ------------------------------------------------------------ |
@@ -129,13 +129,13 @@ character. The table MUST contain the following fields:
 | `sizeY`       | The height of the terminal. This MUST be an integer.         |
 | `cursorX`     | The cursor's X position. This MUST be an integer.            |
 | `cursorY`     | The cursor's Y position. This MUST be an integer.            |
-| `cursorBlink` | Whether the cursor is blinking. This MUST be either `true` or `false. |
+| `cursorBlink` | Whether the cursor is blinking. This MUST be either `true` or `false`. |
 | `text`        | A table representing the textual contents of the terminal.†  |
 | `textColor`   | A table representing the background color of the terminal.\*†|
 | `backColor`   | A table representing the textual contents of the terminal.\*†|
 
 \* All colors use the codes defined in [COS 4][cospaint]. The client MAY choose
-to ignore colours if it incapible of rendering them.
+to ignore colours if it is incapable of rendering them.
 
 † Each entry of the table represents a separate line of the terminal. There must
 be `sizeY` table entries, each being `sizeX` characters long.
@@ -144,4 +144,4 @@ be `sizeY` table entries, each being `sizeX` characters long.
  - [nsh and its related utilities](https://github.com/lyqyd/cc-netshell/) uses
    TRoR and various extensions to allow interacting with a computer remotely.
 
-[cospaint]: /File-Formats/image/paint.md "COS 4: Paintutils Image"
+[cospaint]: /File-Formats/image/paint.md#color-codes "COS 4: Paintutils Image"

--- a/Protocols/tror.md
+++ b/Protocols/tror.md
@@ -86,7 +86,7 @@ The client should send an appropriate response packet to these requests:
 | Code | Packet contents | Description                                         |
 | ---- | --------------- | --------------------------------------------------- |
 | `TI` | `<w>,<h>,<col>` | Send the client terminal's width, height and color support to the server. This packet MAY be sent at any time and SHOULD be sent whenever a `TQ` packet is received. |
-| `TG` | `<x>,<y>`       | Send the client terminal's cursor position. This MUST be sent when receiving a `TG` packet and SHOULD NOT be sent at any other time. |
+| `TP` | `<x>,<y>`       | Send the client terminal's cursor position. This MUST be sent when receiving a `TG` packet and SHOULD NOT be sent at any other time. |
 
 ### Client events
 The client MAY send events such as key presses to the client. However the client

--- a/Protocols/tror.md
+++ b/Protocols/tror.md
@@ -138,7 +138,7 @@ to ignore colours if it incapible of rendering them.
 be `sizeY` table entries, each being `sizeX` characters long.
 
 ## Available Utilities
- - [nsh and its related utilities](https://github.com/lyqyd/cc-netshell/) does things
-   differently.
+ - [nsh and its related utilities](https://github.com/lyqyd/cc-netshell/) uses
+   TRoR and various extensions to allow interacting with a computer remotely.
 
 [cospaint]: /File-Formats/image/paint.md "COS 4: Paintutils Image"


### PR DESCRIPTION
Pinging @lyqyd  and @apemanzilla

Background: I'm proposing to add a method of broadcasting terminal state over a TCP socket, and was planning to use TRoR for this. I've made some modifications to the [original standard](http://www.computercraft.info/forums2/index.php?/topic/6484-) to help make this easier.

This is a very rough draft ATM: I'm going away over the weekend and wanted to run this up a flagpole to get some initial feedback. One of the key aims of this is to not require a Lua parser to achieve minimal functionality, therefore I've replaced most instances of `textutils.serialize`/`.unserialize` with a different format.

I'm happy to rename this to something which isn't an existing standard as it isn't backwards compatible with it.
## Changes from the original standard/nsh implementation
- Packets cannot contain the `\n` character: this is used to separate multiple packets.
- The arbitary data cannot contain `;`: this seems to lead to parsing ambiguities in `TW` if the terminal text contains `;`.
- Add `TY` and `TV` packets to allow blitting a single line/the entire terminal. 
- Removed `TG` packet: I'm not 100% sure of the purpose of this.
- Add `TR` packet to allow resizing the client's terminal: this allows the server to broadcast to multiple clients without caring what size they all are.
- `TI` sends width, height _and_ color support. We could potentially merge the `TD` and `TA` packets.
- `EV` uses a comma separated list instead of `textutils.serialize`.
## Changes still needed
- [x] ~~`SQ`, `SR`, `SP` and `SC` - @lyqyd I'm not 100% sure what is going on here.~~ Added `SP` and `SC`.
- [x] Add `TT` packet.
- ~~File transmitting. I don't know if we want this as a separate protocol.~~

Thoughts?
